### PR TITLE
Reduce the default INGESTRATE to 1k

### DIFF
--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -1604,7 +1604,7 @@ class Shell(cmd.Cmd):
         Available COPY FROM options and defaults:
 
           CHUNKSIZE=5000          - the size of chunks passed to worker processes
-          INGESTRATE=100000       - an approximate ingest rate in rows per second
+          INGESTRATE=1000         - an approximate ingest rate in rows per second
           MINBATCHSIZE=10         - the minimum size of an import batch
           MAXBATCHSIZE=20         - the maximum size of an import batch
           MAXROWS=-1              - the maximum number of rows, -1 means no maximum

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -346,7 +346,7 @@ class CopyTask(object):
         copy_options['floatprecision'] = int(opts.pop('floatprecision', '5'))
         copy_options['doubleprecision'] = int(opts.pop('doubleprecision', '12'))
         copy_options['chunksize'] = int(opts.pop('chunksize', 5000))
-        copy_options['ingestrate'] = int(opts.pop('ingestrate', 100000))
+        copy_options['ingestrate'] = int(opts.pop('ingestrate', 1000))
         copy_options['maxbatchsize'] = int(opts.pop('maxbatchsize', 20))
         copy_options['minbatchsize'] = int(opts.pop('minbatchsize', 10))
         copy_options['reportfrequency'] = float(opts.pop('reportfrequency', 0.25))


### PR DESCRIPTION
INGESTRATE defaults to 100k which is too high to load data into yugabyte, esp with transactional tables. We've seen the default configuration run into timeouts, and common guidance from the engineers is to specify an option for INGESRATE/NUMWORKERS, etc to make the COPY FROM command perform better. 

The PR is to reduce the default INGESTRATE from 100k to 1k so that the default configuration works well, without problems. If the cluster is able to handle more ops, the COPY command can specify the rate to increase the throughput.