### PR TITLE
[cqlsh] Add environment variable to validate server hostname

### DIFF
--- a/pylib/cqlshlib/sslhandling.py
+++ b/pylib/cqlshlib/sslhandling.py
@@ -53,6 +53,13 @@ def ssl_settings(host, config_file, env=os.environ):
         ssl_validate = get_option('ssl', 'validate')
     ssl_validate = ssl_validate is None or ssl_validate.lower() != 'false'
 
+    ssl_check_hostname_str = env.get('SSL_CHECK_HOSTNAME')
+    if ssl_check_hostname_str is None:
+        ssl_check_hostname_str = get_option('ssl', 'check_hostname')
+    ssl_check_hostname = False
+    if ssl_check_hostname_str is not None and ssl_check_hostname_str.lower() == 'true':
+        ssl_check_hostname = True
+
     ssl_version_str = env.get('SSL_VERSION')
     if ssl_version_str is None:
         ssl_version_str = get_option('ssl', 'version')
@@ -87,4 +94,6 @@ def ssl_settings(host, config_file, env=os.environ):
     return dict(ca_certs=ssl_certfile,
                 cert_reqs=ssl.CERT_REQUIRED if ssl_validate else ssl.CERT_NONE,
                 ssl_version=ssl_version,
-                keyfile=userkey, certfile=usercert)
+                keyfile=userkey,
+                certfile=usercert,
+                check_hostname=ssl_validate and ssl_check_hostname)


### PR DESCRIPTION
**Summary**

This change adds the ability for ycqlsh to check the server certificate to verify that it matches the connection hostname. Verification is still disabled by default but can be enabled by using the SSL_CHECK_HOSTNAME env var or an equivalent cqlsh entry.

**Test Plan**

Start a yugabyte cluster with client cert CN set to 127.0.0.1 and server listening on 127.0.0.1. Also forward connections from 127.0.0.2:9042 to 127.0.0.1:9042 by using an ssh tunnel. This way, connections to 127.0.0.1 should pass server cert verification but conns to 127.0.0.2 should fail.

 For all cases below, set `export SSL_CERTFILE=<ca.crt>`

Test cases
1. `/usr/bin/python3 ~/code/cqlsh/bin/ycqlsh.py --ssl 127.0.0.2 9042` succeeds with no env vars as before.
2. `SSL_CHECK_HOSTNAME=true /usr/bin/python3 ~/code/cqlsh/bin/ycqlsh.py --ssl 127.0.0.2 9042` fails with
   ```
   /home/sanketh/code/cqlsh/bin/ycqlsh.py:464: DeprecationWarning: Legacy execution parameters will be removed in 4.0. 
   Consider using execution profiles.
   /home/sanketh/code/cqlsh/bin/ycqlsh.py:464: DeprecationWarning: Using ssl_options without ssl_context is deprecated and 
   will result in an error in the next major release. Please use ssl_context to prepare for that release.
   Connection error: ('Unable to connect to any servers', {'127.0.0.2:9042': OSError(None, 'Tried connecting to [(\'127.0.0.2\', 9042)]. Last error: ("hostname \'127.0.0.2\' doesn\'t match \'127.0.0.1\'",)')})
   ```
3. `SSL_CHECK_HOSTNAME=false/usr/bin/python3 ~/code/cqlsh/bin/ycqlsh.py --ssl 127.0.0.2 9042` succeeds
4. `SSL_VALIDATE=false SSL_CHECK_HOSTNAME=true /usr/bin/python3 ~/code/cqlsh/bin/ycqlsh.py --ssl 127.0.0.2 9042` succeeds