### PR TITLE
Print Timing for all DMLs

### DIFF
--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -1123,6 +1123,9 @@ class Shell(cmd.Cmd):
             # CAS INSERT/UPDATE
             self.writeresult("")
             self.print_static_result(result, self.parse_for_update_meta(statement.query_string), time_end)
+        else :
+            if self.timing_enabled and time_end is not None:
+                self.writeresult("%.2f milliseconds elapsed" % (time_end*1000), color=BLUE)
         self.flush_output()
         return True, future
 

--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -1123,7 +1123,7 @@ class Shell(cmd.Cmd):
             # CAS INSERT/UPDATE
             self.writeresult("")
             self.print_static_result(result, self.parse_for_update_meta(statement.query_string), time_end)
-        else :
+        else:
             if self.timing_enabled and time_end is not None:
                 self.writeresult("%.2f milliseconds elapsed" % (time_end*1000), color=BLUE)
         self.flush_output()


### PR DESCRIPTION
**Description for command TIMING [ON|OFF] :**

TIMING [ycqlsh]

Enables or disables simple request round-trip timing, as measured on the current ycqlsh session.

Usage:

- TIMING ON

> Enables round-trip timing for all further requests.

- TIMING OFF

> Disables timing.

- TIMING

> TIMING with no arguments shows the current timing status.

**Testing:**

Tested all DMLs manually on a local cluster.