### PR TITLE
Added `os.path.expanduser` to default cqlshrc path in ycqlsh.py

### DIFF
--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -277,10 +277,10 @@ try:
 except OSError:
     print('\nWarning: Cannot create directory at `%s`. Command history will not be saved. Please check what was the environment property CQL_HISTORY set to.\n' % HISTORY_DIR)
 
-DEFAULT_CQLSHRC = os.path.join('~', '.cassandra', 'cqlshrc')
+DEFAULT_CQLSHRC = os.path.expanduser(os.path.join('~', '.cassandra', 'cqlshrc'))
 
 if hasattr(options, 'cqlshrc'):
-    CONFIG_FILE = options.cqlshrc
+    CONFIG_FILE = os.path.expanduser(options.cqlshrc)
     if not os.path.exists(CONFIG_FILE):
         print('\nWarning: Specified cqlshrc location `%s` does not exist.  Using `%s` instead.\n' % (CONFIG_FILE, DEFAULT_CQLSHRC))
         CONFIG_FILE = DEFAULT_CQLSHRC


### PR DESCRIPTION
Changes done are according to this [commit](https://github.com/apache/cassandra/commit/cd5f215c72dde43d367c065cdc9cd18d940623bd) on upstream code.