### PR TITLE
Fixed incomplete error message

### DIFF
--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -1091,7 +1091,7 @@ class Shell(cmd.Cmd):
         try:
             result = future.result()
         except CQL_ERRORS as err:
-            err_msg = ensure_text(err.message if hasattr(err, 'message') else str(err))
+            err_msg = ensure_text(err.message if (hasattr(err, 'message') and err.message.strip()!="") else str(err))
             self.printerr(str(err.__class__.__name__) + ": " + err_msg)
         except Exception:
             import traceback


### PR DESCRIPTION
Using python2 was showing incomplete error messages as the err.message field is empty. Added a check to skip that if it is empty.