### PR TITLE
Fixed incomplete error message 

### DIFF
--- a/bin/ycqlsh.py
+++ b/bin/ycqlsh.py
@@ -924,7 +924,7 @@ class Shell(cmd.Cmd):
                 except EOFError:
                     self.handle_eof()
                 except CQL_ERRORS as cqlerr:
-                    self.printerr(cqlerr.message)
+                    self.printerr(str(cqlerr))
                 except KeyboardInterrupt:
                     self.reset_statement()
                     print('')
@@ -1091,7 +1091,7 @@ class Shell(cmd.Cmd):
         try:
             result = future.result()
         except CQL_ERRORS as err:
-            err_msg = ensure_text(err.message if hasattr(err, 'message') else str(err))
+            err_msg = ensure_text(str(err))
             self.printerr(str(err.__class__.__name__) + ": " + err_msg)
         except Exception:
             import traceback

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -141,7 +141,7 @@ class SendingChannel(object):
                     msg = self.pending_messages.get()
                     self.pipe.send(msg)
                 except Exception as e:
-                    printmsg('%s: %s' % (e.__class__.__name__, e.message if hasattr(e, 'message') else str(e)))
+                    printmsg('%s: %s' % (e.__class__.__name__, str(e)))
 
         feeding_thread = threading.Thread(target=feed)
         feeding_thread.setDaemon(True)
@@ -1335,7 +1335,7 @@ class FeedingProcess(mp.Process):
         try:
             reader.start()
         except IOError as exc:
-            self.outmsg.send(ImportTaskError(exc.__class__.__name__, exc.message if hasattr(exc, 'message') else str(exc)))
+            self.outmsg.send(ImportTaskError(exc.__class__.__name__, str(exc)))
 
         channels = self.worker_channels
         max_pending_chunks = self.max_pending_chunks
@@ -1364,7 +1364,7 @@ class FeedingProcess(mp.Process):
                     if rows:
                         sent += self.send_chunk(ch, rows)
                 except Exception as exc:
-                    self.outmsg.send(ImportTaskError(exc.__class__.__name__, exc.message if hasattr(exc, 'message') else str(exc)))
+                    self.outmsg.send(ImportTaskError(exc.__class__.__name__, str(exc)))
 
                 if reader.exhausted:
                     break
@@ -2126,7 +2126,7 @@ class ImportConversion(object):
 
                 if self.debug:
                     traceback.print_exc()
-                raise ParseError("Failed to parse %s : %s" % (v, e.message if hasattr(e, 'message') else str(e)))
+                raise ParseError("Failed to parse %s : %s" % (v, str(e)))
 
         return [convert(conv, val) for conv, val in zip(converters, row)]
 
@@ -2566,7 +2566,7 @@ class ImportProcess(ChildProcess):
                 pk = get_row_partition_key_values(row)
                 rows_by_ring_pos[get_ring_pos(ring, pk_to_token_value(pk))].append(row)
             except Exception as e:
-                errors[e.message if hasattr(e, 'message') else str(e)].append(row)
+                errors[str(e)].append(row)
 
         if errors:
             for msg, rows in errors.items():

--- a/pylib/cqlshlib/copyutil.py
+++ b/pylib/cqlshlib/copyutil.py
@@ -2494,7 +2494,7 @@ class ImportProcess(ChildProcess):
             try:
                 return conv.convert_row(r)
             except Exception as err:
-                errors[err.message if hasattr(err, 'message') else str(err)].append(r)
+                errors[str(err)].append(r)
                 return None
 
         converted_rows = [_f for _f in [convert_row(r) for r in rows] if _f]
@@ -2606,7 +2606,7 @@ class ImportProcess(ChildProcess):
     def report_error(self, err, chunk=None, rows=None, attempts=1, final=True):
         if self.debug and sys.exc_info()[1] == err:
             traceback.print_exc()
-        err_msg = err.message if hasattr(err, 'message') else str(err)
+        err_msg = str(err)
         self.outmsg.send(ImportTaskError(err.__class__.__name__, err_msg, rows, attempts, final))
         if final and chunk is not None:
             self.update_chunk(rows, chunk)


### PR DESCRIPTION
**Description**
Using python2.7, On running a `drop keyspace` query, incomplete error message is shown:

```
ycqlsh> drop keyspace new;
NoHostAvailable: 
```

**Fix**
Quoting from https://github.com/yugabyte/cqlsh/pull/23#pullrequestreview-1867543110

```
- in python2.7 the message field return empty string because multiple arguments was passed to exception's object constructor
- the message field is deprecated since 2.6. In case YB is not interested in supporting python prior to 2.7 str(err) must be used instead of message field. In other case it seems reasonable to create helper function and use it everywhere
```

Since the supported python version are [python2.7 or python3.6+](https://github.com/yugabyte/cqlsh/blob/master/bin/ycqlsh#L65) and [message field is deprecated since python2.6](https://peps.python.org/pep-0352/), the fix is to simply use str(err) instead of err.message

**Testing**
Tested locally and verified that proper error message is printed for the `drop keyspace` query.

```
ycqlsh> drop keyspace new;
NoHostAvailable: ('Unable to complete the operation against any hosts', {<Host: 127.0.0.1:9042 datacenter1>: <Error from server: code=0000 [Server error] message="Server Error. Cannot delete keyspace which has table: k [id=d98ecdf7bfd9436ca627d6c7dbd22394], request: namespace { name: "new" }: NAMESPACE_IS_NOT_EMPTY (master error 14)
drop keyspace new;
              ^^^
 (ql error -2)">})
```
